### PR TITLE
Dafault http only and secure cookie

### DIFF
--- a/WebApplication1/WebApplication1/Default.aspx.cs
+++ b/WebApplication1/WebApplication1/Default.aspx.cs
@@ -13,6 +13,9 @@ namespace WebApplication1
         {
             Trace.Write("My trace message");
             Trace.Warn("My trace warn");
+
+            var cookie = new HttpCookie("MyCookie", "Milan's cookie");
+            Response.Cookies.Add(cookie);
         }
     }
 }

--- a/WebApplication1/WebApplication1/Web.config
+++ b/WebApplication1/WebApplication1/Web.config
@@ -19,7 +19,7 @@
     <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\aspnet-WebApplication1-20160225034314.mdf;Initial Catalog=aspnet-WebApplication1-20160225034314;Integrated Security=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <system.web>
-    <httpCookies httpOnlyCookies="true"/>
+    <httpCookies httpOnlyCookies="true" requireSSL="true"/>
     <trace enabled="true"/>
     <authentication mode="None" />
     <compilation debug="true" targetFramework="4.5.2" />

--- a/WebApplication1/WebApplication1/Web.config
+++ b/WebApplication1/WebApplication1/Web.config
@@ -19,6 +19,7 @@
     <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\aspnet-WebApplication1-20160225034314.mdf;Initial Catalog=aspnet-WebApplication1-20160225034314;Integrated Security=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <system.web>
+    <httpCookies httpOnlyCookies="true"/>
     <trace enabled="true"/>
     <authentication mode="None" />
     <compilation debug="true" targetFramework="4.5.2" />


### PR DESCRIPTION
Behaves weird on localhost in Firefox (it does set Secure cookie via insecure http request). Workaround is to use `hosts` file and access the web not by `http://localhost` but a domain name like `http://my.domain.com`.
